### PR TITLE
Feature/issue 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 
 # Distribution / packaging
 .Python
+envdir/
 env/
 build/
 develop-eggs/

--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 import os
 import sys
+import envdir
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sigcaw.settings")
 
     from django.core.management import execute_from_command_line
+
+    envdir.open()
 
     execute_from_command_line(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ Pillow==3.2.0
 django-phonenumber-field==1.1.0
 phonenumberslite==7.4.4
 pytz==2016.4
+envdir==0.7
+

--- a/sigcaw/settings.py
+++ b/sigcaw/settings.py
@@ -20,10 +20,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'n3eycd^u=65if676)o)o0ekcm8)r5yc-u3u14@10as3jvb6vei'
+SECRET_KEY = os.environ.get('SECRET_KEY', '')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', True)
 
 ALLOWED_HOSTS = []
 
@@ -76,14 +76,25 @@ WSGI_APPLICATION = 'sigcaw.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
-
+'''
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+'''
 
+DATABASES = {
+    'default': {
+        'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.sqlite3'),
+        'NAME': os.environ.get('DB_NAME', os.path.join(BASE_DIR, 'db.sqlite3')),
+        'USER': os.environ.get('DATABASE_USER', ''),
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD', ''),
+        'HOST': os.environ.get('DATABASE_HOST', ''),
+        'PORT': os.environ.get('DATABASE_PORT', ''),
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators


### PR DESCRIPTION
Agrego envdir al requirements.txt para poder sacar info sensible del settings.py en variables de entornos.
En el mismo nivel que el file manage.py se debe crear una carpeta llamada "envdir" allí crear archivos con letra mayúscula. Cada archivo se una variable de entorno y en el interior del archivo va el contenido de la variable de entorno.
Se modifico el manage.py para que automáticamente se llame a envdir quien va a escanear el directorio buscando los archivos creados y cargará a los mismo en variables de entornos reales en el SO que se esté usando.